### PR TITLE
Remove background image in dark mode

### DIFF
--- a/src/components/Container.jsx
+++ b/src/components/Container.jsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
+import { useContext } from 'react';
+import { ThemeContext } from '../utility/ThemeContext.jsx';
 
-const Container = styled.div`
-
+const StyledContainer = styled.div`
     --background-color: var(--secondary-color);
     width:100vw;
     min-height:100vh;
@@ -13,13 +14,21 @@ const Container = styled.div`
     position:relative;
     background: var(--primary-color);
     padding-bottom:1rem;
-    
-    background:url(https://i.postimg.cc/GhGPCkYv/image.png) top left / contain;
+
+    ${({ $theme }) => $theme !== 'dark' && `
+        background:url(https://i.postimg.cc/GhGPCkYv/image.png) top left / contain;
+    `}
+
     --background:url(https://i.postimg.cc/YCXvK9X1/Screenshot-2024-11-09-at-1-23-22-PM.png);
-
-
-    
-             
 `;
+
+const Container = ({ className, children }) => {
+    const { theme } = useContext(ThemeContext);
+    return (
+        <StyledContainer className={className} $theme={theme}>
+            {children}
+        </StyledContainer>
+    );
+};
 
 export default Container;


### PR DESCRIPTION
## Summary
- adjust Container to hide the background image when dark theme is active

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68877bfb3d3c832cb53f6b527f632b7d