### PR TITLE
Fix header colors in dark mode

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,7 +13,7 @@ import ProfilePic from './ProfilePic';
 import {VITE_FEATURE_MULTIPLE_CLIENTS} from '../utility/constants';
 import { useFeatureFlags } from '@geejay/use-feature-flags';
 
-
+import {getLinkClasses} from '../utility/getLinkClasses';
 
 
 
@@ -70,12 +70,7 @@ export default function Header({ theme, onToggleTheme }) {
   }
 
   
-  const getLinkClasses = (isActive) => {
-    if (theme === 'dark') {
-      return `${isActive ? 'text-yellow-400' : 'text-white'} hover:text-yellow-400`;
-    }
-    return `${isActive ? 'text-slate-800' : 'text-[--main-2]'} hover:text-[--main-2]`;
-  };
+  
 
   return (
 
@@ -90,7 +85,7 @@ export default function Header({ theme, onToggleTheme }) {
       <div className='hidden md:flex justify-around items-center gap-4 items-end'> 
      <Link
         to={user.role == "admin" ? `/admin` : `/dashboard`}
-        className={getLinkClasses(location.pathname === "/dashboard")}
+        className={getLinkClasses(theme,location.pathname === "/dashboard")}
       >
         Data
       </Link>
@@ -98,13 +93,13 @@ export default function Header({ theme, onToggleTheme }) {
     <div className='flex gap-4'>
   <Link
         to="/dashboard#graphs"
-        className={getLinkClasses(location.hash === "#graphs" && location.pathname === "/dashboard")}
+        className={getLinkClasses(theme,location.hash === "#graphs" && location.pathname === "/dashboard")}
       >
         Graphs
       </Link>
       <Link
         to="/dashboard#forecast"
-        className={getLinkClasses(location.hash === "#forecast" && location.pathname === "/dashboard")}
+        className={getLinkClasses(theme,location.hash === "#forecast" && location.pathname === "/dashboard")}
       >
         Forecasts
       </Link>
@@ -114,7 +109,7 @@ export default function Header({ theme, onToggleTheme }) {
  
     <Link
         to="/reports"
-        className={getLinkClasses(location.pathname === "/reports")}
+        className={getLinkClasses(theme,location.pathname === "/reports")}
       >
         Reports
       </Link>
@@ -122,7 +117,7 @@ export default function Header({ theme, onToggleTheme }) {
   {((user.role != "admin" && user.role != "contact" )|| (user.role == "contact" && user.co_owner == true) )  && (
       <Link
         to="/assign-locations"
-        className={getLinkClasses(location.pathname === "/assign-locations" || location.pathname === "/assignments")}
+        className={getLinkClasses(theme,location.pathname === "/assign-locations" || location.pathname === "/assignments")}
       >
         Assignments
       </Link>
@@ -132,7 +127,7 @@ export default function Header({ theme, onToggleTheme }) {
   {convertTier(user) == 4 ? (
       <Link
         to="/settings-admin"
-        className={getLinkClasses([
+        className={getLinkClasses(theme,[
           "/location-list",
           "/contact-list",
           "/settings-general",
@@ -145,7 +140,7 @@ export default function Header({ theme, onToggleTheme }) {
       <Upgrade tier={1} showMsg={false}>
         <Link
           to="/contact-list"
-          className={getLinkClasses([
+          className={getLinkClasses(theme,[
             "/location-list",
             "/contact-list",
             "/settings-general",
@@ -161,7 +156,7 @@ export default function Header({ theme, onToggleTheme }) {
   {VITE_FEATURE_MULTIPLE_CLIENTS != "true"  && (
       <Link
         onClick={logout}
-        className={getLinkClasses(location.pathname === "/")}
+        className={getLinkClasses(theme,location.pathname === "/")}
       >
         Logout
       </Link>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -70,6 +70,13 @@ export default function Header({ theme, onToggleTheme }) {
   }
 
   
+  const getLinkClasses = (isActive) => {
+    if (theme === 'dark') {
+      return `${isActive ? 'text-yellow-400' : 'text-white'} hover:text-yellow-400`;
+    }
+    return `${isActive ? 'text-slate-800' : 'text-[--main-2]'} hover:text-[--main-2]`;
+  };
+
   return (
 
     <div className='header flex h-[4rem] overflow-x-show md:flex px-5 justify-between md:justify-around md:gap-0 gap-4 top-0 left-0 fixed  z-50 items-center bg-[var(--header-bg)] text-slate-800 font-bold w-full md:min-h-24 md:text-xl border-b'>
@@ -81,42 +88,84 @@ export default function Header({ theme, onToggleTheme }) {
         <i className='fas fa-search absolute pl-4 pb-4 top-10 text-slate-400 text-sm'></i>
       </div>
       <div className='hidden md:flex justify-around items-center gap-4 items-end'> 
-     <Link to={user.role == "admin" ? `/admin`:`/dashboard`} className={`hover:text-[--main-2] ${location.pathname === "/dashboard" ? "text-slate-800" : "text-[--main-2]"}`}>
-    Data
-  </Link>
+     <Link
+        to={user.role == "admin" ? `/admin` : `/dashboard`}
+        className={getLinkClasses(location.pathname === "/dashboard")}
+      >
+        Data
+      </Link>
   {convertTier(user) != 4 && (
     <div className='flex gap-4'>
-  <Link to="/dashboard#graphs" className={`hover:text-[--main-2] ${location.hash === "#graphs" && location.pathname === "/dashboard" ? "text-slate-800" : "text-[--main-2]"}`}>
-    Graphs
-  </Link>
-  <Link to="/dashboard#forecast" className={`hover:text-[--main-2] ${location.hash === "#forecast" && location.pathname === "/dashboard" ? "text-slate-800" : "text-[--main-2]"}`}>
-    Forecasts
-  </Link>
+  <Link
+        to="/dashboard#graphs"
+        className={getLinkClasses(location.hash === "#graphs" && location.pathname === "/dashboard")}
+      >
+        Graphs
+      </Link>
+      <Link
+        to="/dashboard#forecast"
+        className={getLinkClasses(location.hash === "#forecast" && location.pathname === "/dashboard")}
+      >
+        Forecasts
+      </Link>
   </div>
 )}
 
  
-    <Link to="/reports" className={location.pathname === "/reports" ? "text-slate-800" : "text-[--main-2]"}>
-      Reports
-    </Link>
+    <Link
+        to="/reports"
+        className={getLinkClasses(location.pathname === "/reports")}
+      >
+        Reports
+      </Link>
   
-  {((user.role != "admin" && user.role != "contact" )|| (user.role == "contact" && user.co_owner == true) )  && (<Link to="/assign-locations" className={location.pathname === "/assign-locations" || location.pathname === "/assignments" ? "text-slate-800" : "text-[--main-2]"}>
-    Assignments 
-  </Link>)}
+  {((user.role != "admin" && user.role != "contact" )|| (user.role == "contact" && user.co_owner == true) )  && (
+      <Link
+        to="/assign-locations"
+        className={getLinkClasses(location.pathname === "/assign-locations" || location.pathname === "/assignments")}
+      >
+        Assignments
+      </Link>
+    )}
   <div>
 
-    {convertTier(user) == 4 ? (<Link to="/settings-admin" className={["/location-list", "/contact-list", "/settings-general"].includes(location.pathname) ? "text-slate-800" : "text-[--main-2]"}>
-    Settings
-  </Link>):((user.role != "admin" && user.role != "contact" )|| (user.role == "contact" && user.co_owner == true) ) && (<Upgrade  tier={1} showMsg={false}><Link to="/contact-list" className={["/location-list", "/contact-list", "/settings-general","/client-form"].includes(location.pathname) ? "text-slate-800" : "text-[--main-2]"}>
-    Settings 
-  </Link></Upgrade>)}
+  {convertTier(user) == 4 ? (
+      <Link
+        to="/settings-admin"
+        className={getLinkClasses([
+          "/location-list",
+          "/contact-list",
+          "/settings-general",
+        ].includes(location.pathname))}
+      >
+        Settings
+      </Link>
+    ) :
+    ((user.role != "admin" && user.role != "contact" )|| (user.role == "contact" && user.co_owner == true) ) && (
+      <Upgrade tier={1} showMsg={false}>
+        <Link
+          to="/contact-list"
+          className={getLinkClasses([
+            "/location-list",
+            "/contact-list",
+            "/settings-general",
+            "/client-form",
+          ].includes(location.pathname))}
+        >
+          Settings
+        </Link>
+      </Upgrade>
+    )}
   </div>
   
-  {VITE_FEATURE_MULTIPLE_CLIENTS != "true"  &&
-    <Link onClick={logout} className={location.pathname === "/" ? "text-slate-800" : "text-[--main-2]"}>
-      Logout
-    </Link>
-  }
+  {VITE_FEATURE_MULTIPLE_CLIENTS != "true"  && (
+      <Link
+        onClick={logout}
+        className={getLinkClasses(location.pathname === "/")}
+      >
+        Logout
+      </Link>
+    )}
 
 
   {VITE_FEATURE_MULTIPLE_CLIENTS == "true" && <ProfilePic  mini={true} />}

--- a/src/utility/getLinkClasses.js
+++ b/src/utility/getLinkClasses.js
@@ -1,0 +1,6 @@
+export const getLinkClasses = (theme,isActive) => {
+    if (theme === 'dark') {
+      return `${isActive ? 'text-yellow-400' : 'text-white'} hover:text-yellow-400`;
+    }
+    return `${isActive ? 'text-slate-800' : 'text-[--main-2]'} hover:text-[--main-2]`;
+  };


### PR DESCRIPTION
## Summary
- make header links adapt to theme
- show white links and yellow active link in dark mode

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_68877d2be298832c90c9ebba2158bcbe