### PR TITLE
Use getLinkClasses for various settings links

### DIFF
--- a/src/components/SettingsMenu.jsx
+++ b/src/components/SettingsMenu.jsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import Upgrade from './Upgrade';
 import { useSelector } from 'react-redux';
 import { convertTier } from '../utility/loginUser';
+import { ThemeContext } from '../utility/ThemeContext.jsx';
+import { getLinkClasses } from '../utility/getLinkClasses';
 
 const SettingsMenu = ({ activeTab }) => {
   const user = useSelector((state) => state.userInfo.user);
+  const { theme } = useContext(ThemeContext);
   return (
     <div className="flex justify-start rounded space-x-6 mb-8 self-start bg-[transparent] w-full p-2">
       <Upgrade showMsg={false} tier={4}>
@@ -21,7 +24,7 @@ const SettingsMenu = ({ activeTab }) => {
        
       {window.innerWidth > 600 && (<Link
         to="/contact-list"
-        className={`text-blue-500 hover:text-blue-700 font-bold border-b-2 ${
+        className={`${getLinkClasses(theme, activeTab === 'contacts')} font-bold border-b-2 ${
           activeTab === 'contacts' ? 'border-blue-500' : 'border-transparent'
         }`}
       >
@@ -30,7 +33,7 @@ const SettingsMenu = ({ activeTab }) => {
       {convertTier(user) !=4 && window.innerWidth > 600 && (
        <Link
         to="/location-list"
-        className={`text-blue-500 hover:text-blue-700 font-bold border-b-2 ${
+        className={`${getLinkClasses(theme, activeTab === 'locations')} font-bold border-b-2 ${
           activeTab === 'locations' ? 'border-blue-500' : 'border-transparent'
         }`}
       >
@@ -39,7 +42,7 @@ const SettingsMenu = ({ activeTab }) => {
       )}
       {!user.is_superuser && <Link
         to="/settings-general"
-        className={`text-blue-500 hover:text-blue-700 font-bold border-b-2 ${
+        className={`${getLinkClasses(theme, activeTab === 'notifications')} font-bold border-b-2 ${
           activeTab === 'notifications' ? 'border-blue-500' : 'border-transparent'
         }`}
         >
@@ -47,7 +50,7 @@ const SettingsMenu = ({ activeTab }) => {
       </Link>}
       <Link
         to="/client-form"
-        className={`${user.is_superuser && 'hidden'} text-blue-500 hover:text-blue-700 font-bold border-b-2 ${
+        className={`${user.is_superuser && 'hidden'} ${getLinkClasses(theme, activeTab === (!user.is_superuser ? 'mysubscription' : 'clients'))} font-bold border-b-2 ${
           activeTab === (!user.is_superuser ? 'mysubscription' : 'clients') ? 'border-blue-500' : 'border-transparent'
         }`}
 

--- a/src/components/Subheader.jsx
+++ b/src/components/Subheader.jsx
@@ -1,27 +1,36 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { NavLink } from 'react-router-dom';
+import { ThemeContext } from '../utility/ThemeContext.jsx';
+import { getLinkClasses } from '../utility/getLinkClasses';
 
 const SubHeader = () => {
+  const { theme } = useContext(ThemeContext);
   const linkStyle = "py-4 text-center hover:bg-lime-800/100 ";
-  const activeStyle = "bg-blue-500 text-white font-bold ";
+  const activeStyle = "bg-blue-500 font-bold ";
 
   return (
     <div className=" flex justify-center items-center  rounded-2xl w-1/2 md:min-w-full overflow-hidden shadow-md mb-4 bg-[#99ba93] ">
       <NavLink
         to="/location-list"
-        className={({ isActive }) => `${linkStyle} ${isActive ? activeStyle : 'text-[white]'}` + ` w-full`}
+        className={({ isActive }) =>
+          `${linkStyle}${isActive ? activeStyle : ''} ${getLinkClasses(theme, isActive)}` + ` w-full`
+        }
       >
         Locations
       </NavLink>
       <NavLink
         to="/contact-list"
-        className={({ isActive }) => `${linkStyle} ${isActive ? activeStyle : 'text-[white]'}` + ` w-full`}
+        className={({ isActive }) =>
+          `${linkStyle}${isActive ? activeStyle : ''} ${getLinkClasses(theme, isActive)}` + ` w-full`
+        }
       >
         Contacts
       </NavLink>
       <NavLink
         to="/settings-general"
-        className={({ isActive }) => `${linkStyle} ${isActive ? activeStyle : 'text-[white]'}` + ` w-full`}
+        className={({ isActive }) =>
+          `${linkStyle}${isActive ? activeStyle : ''} ${getLinkClasses(theme, isActive)}` + ` w-full`
+        }
       >
         General Settings
       </NavLink>

--- a/src/pages/AccountListPage.jsx
+++ b/src/pages/AccountListPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { FaEdit, FaTrashAlt, FaCheck } from 'react-icons/fa';
 
@@ -6,6 +6,8 @@ import api from '../utility/api';
 import SubHeader from '../components/Subheader';
 import Card from '../components/Card';
 import ContactCSVFileUploadDialog from '../components/ContactCSVFileUploadDialog';
+import { ThemeContext } from '../utility/ThemeContext.jsx';
+import { getLinkClasses } from '../utility/getLinkClasses';
 
 const AccountListPage = () => {
   const [contacts, setContacts] = useState([]);
@@ -13,6 +15,7 @@ const AccountListPage = () => {
   const [totalPages, setTotalPages] = useState(1);
   const [searchTerm, setSearchTerm] = useState('');
   const navigate = useNavigate();
+  const { theme } = useContext(ThemeContext);
 
   const fetchContacts = async (page) => {
     try {
@@ -57,13 +60,13 @@ const AccountListPage = () => {
         </span>
         <Link
           to="/location-list"
-          className="text-blue-500 hover:text-blue-700 font-bold border-b-2 border-transparent hover:border-blue-700"
+          className={`${getLinkClasses(theme, false)} font-bold border-b-2 border-transparent hover:border-blue-700`}
         >
           Modify Locations
         </Link>
         <Link
           to="/settings-general"
-          className="text-blue-500 hover:text-blue-700 font-bold border-b-2 border-transparent hover:border-blue-700"
+          className={`${getLinkClasses(theme, false)} font-bold border-b-2 border-transparent hover:border-blue-700`}
         >
           Notifications
         </Link>

--- a/src/pages/UserAccountProvisioning.jsx
+++ b/src/pages/UserAccountProvisioning.jsx
@@ -1,12 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import Card from '../components/Card';
 import Toggle from '../components/Toggle';
 import { useSelector } from 'react-redux';
+import { ThemeContext } from '../utility/ThemeContext.jsx';
+import { getLinkClasses } from '../utility/getLinkClasses';
 
 const UserAccountProvisioning = () => {
   const [showUpgrade, setShowUpgrade] = useState(false);
   const user = useSelector((state) => state.userInfo.user);
+  const { theme } = useContext(ThemeContext);
   const [settings, setSettings] = useState({
     turnAccountOn: false,
     suspendAccount: false,
@@ -54,20 +57,20 @@ const UserAccountProvisioning = () => {
           <div className="flex justify-start rounded space-x-6 mb-8 self-start bg-[transparent] w-full p-2">
             <Link
               to="/contact-list"
-              className="text-blue-500 hover:text-blue-700 font-bold border-b-2 border-transparent hover:border-blue-700"
+              className={`${getLinkClasses(theme, false)} font-bold border-b-2 border-transparent hover:border-blue-700`}
             >
               Modify Contacts
             </Link>
 
             <Link
               to="/location-list"
-              className="text-blue-500 hover:text-blue-700 font-bold border-b-2 border-transparent hover:border-blue-700"
+              className={`${getLinkClasses(theme, false)} font-bold border-b-2 border-transparent hover:border-blue-700`}
             >
               Modify Locations
             </Link>
             <Link
               to="/settings-general"
-              className="text-blue-500 hover:text-blue-700 font-bold border-b-2 border-transparent hover:border-blue-700"
+              className={`${getLinkClasses(theme, false)} font-bold border-b-2 border-transparent hover:border-blue-700`}
             >
               Notifications
             </Link>


### PR DESCRIPTION
## Summary
- apply link color theming via `getLinkClasses` in SettingsMenu
- apply themed link colors in Subheader
- use `getLinkClasses` for AccountListPage links
- apply themed classes in UserAccountProvisioning

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_688781cdae78832cbcf33841f7b32423