### PR TITLE
Default tier selection to gold in FormWizardDelayed

### DIFF
--- a/src/pages/FormWizardDelayed.tsx
+++ b/src/pages/FormWizardDelayed.tsx
@@ -59,7 +59,7 @@ const FormWizardDelayed = () => {
     companyPhone: '',
     companyEmail: '',
     subscriptionLevel: 'paid', // or 'trial'
-    tier: '',
+    tier: 'gold',
     locationName: '',
     latitude: '',
     longitude: '',


### PR DESCRIPTION
## Summary
- Default tier to gold when user opens FormWizardDelayed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 621 problems)

------
https://chatgpt.com/codex/tasks/task_e_68a70f5e53dc832c911954356a78bc7d