### PR TITLE
feat: improve dark mode contrast for ItemControl

### DIFF
--- a/src/components/ItemControl.jsx
+++ b/src/components/ItemControl.jsx
@@ -9,7 +9,7 @@ import './ItemControl.css';
 // Styled components for the container layout
 export function Container({children, className}){
 
-  return (<div className={`flex flex-col  max-h-[20rem] overflow-auto min-h-[20rem] ${className}`}>{children}</div>)
+  return (<div className={`item-control bg-[--item-control-bg] flex flex-col  max-h-[20rem] overflow-auto min-h-[20rem] ${className}`}>{children}</div>)
 }
 
 const Button = styled.button`

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,7 @@
   --shadow: box-shadow: 0 0 50px #ccc;
   --notification:rgb(71, 84, 102);
   --alert: red;
+  --item-control-bg: var(--primary-color);
 
 }
 
@@ -210,6 +211,7 @@ body.dark {
   --card-background: rgba(55, 65, 81, 0.7);
   --text-color: #f9fafb;
   --header-bg: var(--secondary-color);
+  --item-control-bg: #4B5563;
   background: var(--primary-color);
   color: var(--text-color);
 }


### PR DESCRIPTION
## Summary
- use new CSS variable to lighten ItemControl background in dark mode
- define `--item-control-bg` with dark-mode override for better text contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 621 problems (596 errors, 25 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68aca6db11e8832c9504dacc211fd2ce