### PR TITLE
fix: preserve running total colors in dark mode

### DIFF
--- a/src/components/RainfallTable.jsx
+++ b/src/components/RainfallTable.jsx
@@ -99,7 +99,7 @@ const RainfallTable = ({ location, max = 2 }) => {
             <tr key={index} className="hover:bg-gray-50">
               <td className="px-4 py-2 border-b text-sm">{entry.date}</td>
               <td className={`px-4 py-2 border-b text-sm`}>{entry.hourlyTotal.toFixed(2)}</td>
-              <td className={`px-4 py-2 border-b text-sm  ${VITE_FEATURE_TABLE_COLORS == "true" && entry.total24h.toFixed(2)  >= location.h24_threshold ? location.atlas14_threshold && entry.total24h.toFixed(2)  > location.atlas14_threshold["24h"][0] &&  convertTier(user)  != 1 ? "bg-[red]" : "bg-[orange]" : "bg-[transparent]"}`}>{entry.total24h.toFixed(2)}</td>
+              <td className={`px-4 py-2 border-b text-sm  ${VITE_FEATURE_TABLE_COLORS == "true" && entry.total24h.toFixed(2)  >= location.h24_threshold ? location.atlas14_threshold && entry.total24h.toFixed(2)  > location.atlas14_threshold["24h"][0] &&  convertTier(user)  != 1 ? "bg-[red] dark:bg-[red]" : "bg-[orange] dark:bg-[orange]" : "bg-[transparent]"}`}>{entry.total24h.toFixed(2)}</td>
             </tr>
           ))}
         </tbody>}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+
 
 @font-face {
   font-family: 'MyriadPro';
@@ -631,3 +629,6 @@ header {
   
   
 }
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- ensure RainfallTable running totals retain their color coding under dark theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-self-assign, no-unsafe-finally, and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acaf2296d0832ca520538ecb19aaa8