### PR TITLE
Add GA4 tracking code

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,17 @@
   rel="stylesheet"
   href="https://fonts.googleapis.com/icon?family=Material+Icons"
 />
- 
-</head>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-X81DT5Q8Z7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-X81DT5Q8Z7');
+    </script>
+  </head>
   <body>
     <div  id="root"></div>
     <script type="module" src="/src/main.jsx"></script>


### PR DESCRIPTION
## Summary
- add Google Tag Manager script snippet for GA4 tracking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 619 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c02a0d14d0832caf98a9100e8469d9