### PR TITLE
Add feature-flagged Platinum tier placeholders and RainIQ entitlement

### DIFF
--- a/netlify/functions/create-checkout-session.ts
+++ b/netlify/functions/create-checkout-session.ts
@@ -7,6 +7,7 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-06
 
 // server-side whitelist
 const PRICE_BY_PLAN: Record<string,string> = {
+  platinum: process.env.PRICE_ID_PLATINUM!,
   gold: process.env.PRICE_ID_GOLD!,
   silver: process.env.PRICE_ID_SILVER!,
   bronze: process.env.PRICE_ID_BRONZE!,

--- a/src/components/ClientForm.jsx
+++ b/src/components/ClientForm.jsx
@@ -34,6 +34,7 @@ const ClientForm = ({ clientToEdit,myself }) => {
   const user = useSelector((state) => state.userInfo.user);
   const dispatch = useDispatch();
   const { isActive } = useFeatureFlags();
+  const showPlatinum = isActive('showPlatinum');
 
   useEffect(()=>{
     setTimeout(()=>
@@ -460,6 +461,20 @@ const ClientForm = ({ clientToEdit,myself }) => {
             />
             <label htmlFor="gold">Gold</label>
           </div>
+          {showPlatinum && (
+            <div className="flex items-center">
+              <input
+                type="radio"
+                id="platinum"
+                name="tier"
+                value="platinum"
+                checked={tier === 'platinum'}
+                onChange={(e) =>  e.target.value != tier && myself ? navigate("/upgrade") : setTier('platinum')}
+                className="mr-2"
+              />
+              <label htmlFor="platinum">Platinum</label>
+            </div>
+          )}
         </div>
 
         {/* Form Actions */}

--- a/src/components/ClientForm.jsx
+++ b/src/components/ClientForm.jsx
@@ -462,7 +462,7 @@ const ClientForm = ({ clientToEdit,myself }) => {
             <label htmlFor="gold">Gold</label>
           </div>
           {showPlatinum && (
-            <div className="flex items-center">
+            <div className="flex items-center mt-2">
               <input
                 type="radio"
                 id="platinum"

--- a/src/components/RainIQ.jsx
+++ b/src/components/RainIQ.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { convertTier } from '../utility/loginUser';
 import { useFeatureFlags } from '@geejay/use-feature-flags';
 import api from '../utility/api';
 import { VITE_SOCKETLABS_FROM_EMAIL } from '../utility/constants';
@@ -359,7 +358,8 @@ export default function RainIQ() {
   };
 
   const canAccessRainIQ = useMemo(() => {
-    return convertTier(user) >= 3 || user.is_superuser || isActive('rainIQ');
+    const userTier = user?.clients?.[0]?.tier?.toLowerCase();
+    return userTier === 'platinum' || user.is_superuser || isActive('rainIQ');
   }, [user, isActive]);
 
   const customRangeError = useMemo(() => {

--- a/src/pages/FormWizardDelayed.tsx
+++ b/src/pages/FormWizardDelayed.tsx
@@ -48,6 +48,7 @@ const FormWizardDelayed = () => {
   const { isActive } = useFeatureFlags();
   const isClick2PointEnabled = isActive('click2point');
   const isClick2MapPart2Enabled = isActive('click2mapPart2');
+  const showPlatinum = isActive('showPlatinum');
 
   const [passwordVisible, setPasswordVisible] = useState(false);
   const [showMapPicker, setShowMapPicker] = useState(false);
@@ -365,7 +366,7 @@ sessionStorage.setItem('signup.cache', JSON.stringify({
     },
     body: JSON.stringify({
       email: formData.email,
-      plan: formData.tier, // "gold" | "silver" | "bronze"
+      plan: formData.tier, // "platinum" | "gold" | "silver" | "bronze"
       context: 'wizard' // or: 'upgrade'
     }),
   });
@@ -464,11 +465,11 @@ sessionStorage.setItem('signup.cache', JSON.stringify({
         sort_by_rainfall: true,
       };
 
-      if (newClient.tier === "gold") {
+      if (newClient.tier === "gold" || newClient.tier === "platinum") {
         newClient.forecast_on = true;
         newClient.forecast_combine_locations = true;
       }
-      if (newClient.tier === "gold" || newClient.tier === "silver") {
+      if (newClient.tier === "gold" || newClient.tier === "silver" || newClient.tier === "platinum") {
         newClient.atlas14_on = true;
         newClient.atlas14_24h_on = true;
         newClient.atlas14_1h_on = true;
@@ -709,7 +710,7 @@ sessionStorage.setItem('signup.cache', JSON.stringify({
                 <div className="mb-4">
                   <label className="block">Tier</label>
                   <div className="flex gap-4">
-                    {['gold', 'silver', 'bronze'].map((tier) => (
+                    {(showPlatinum ? ['platinum', 'gold', 'silver', 'bronze'] : ['gold', 'silver', 'bronze']).map((tier) => (
                       <label key={tier}>
                         <input type="radio" name="tier"  value={tier} checked={formData.tier === tier} onChange={handleChange} className='mx-2' />
                         {tier.charAt(0).toUpperCase() + tier.slice(1)}
@@ -807,7 +808,7 @@ sessionStorage.setItem('signup.cache', JSON.stringify({
               </select>
             </div>
 
-            {(formData.tier === "gold" || formData.tier === "silver") && (
+            {(formData.tier === "gold" || formData.tier === "silver" || formData.tier === "platinum") && (
               <div className="mb-4">
                 <label htmlFor="rapidrain" className="block font-bold mb-2">RapidRain Threshold (inches)</label>
                 <div className='m-2 text-sm italic'>

--- a/src/pages/Prices.jsx
+++ b/src/pages/Prices.jsx
@@ -1,5 +1,6 @@
 // src/pages/Prices.jsx
 import React, { useEffect, useRef } from 'react';
+import { useFeatureFlags } from '@geejay/use-feature-flags';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { updateUser } from '../utility/UserSlice';
@@ -24,6 +25,8 @@ export default function Prices({ isSmall = false }) {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const upgradeTrackedRef = useRef(false);
+  const { isActive } = useFeatureFlags();
+  const showPlatinum = isActive('showPlatinum');
 
   // --- Upgrade → create Checkout Session via Netlify function ---
   const handleUpgrade = async (tier) => {
@@ -41,7 +44,7 @@ export default function Prices({ isSmall = false }) {
         },
         body: JSON.stringify({
           email: user.email,
-          plan: tier, // "gold" | "silver" | "bronze"
+          plan: tier, // "platinum" | "gold" | "silver" | "bronze"
         }),
       });
 
@@ -135,17 +138,18 @@ export default function Prices({ isSmall = false }) {
   }, [location.search, isSmall, dispatch, navigate, user]);
 
   const features = [
-    { name: '24/7 Monitoring', gold: true, silver: true, bronze: true },
-    { name: 'Threshold Notification', gold: true, silver: true, bronze: true },
-    { name: 'National Precipitation Forecast', gold: true, silver: true, bronze: true },
-    { name: 'Daily and Monthly Reports', gold: true, silver: true, bronze: false },
-    { name: 'Previous Month Report Only', gold: false, silver: false, bronze: true },
-    { name: 'Contact Notifications', gold: true, silver: true, bronze: true },
-    { name: 'Excessive Rainfall', gold: true, silver: true, bronze: false },
-    { name: 'RapidRain', gold: true, silver: true, bronze: false },
-    { name: 'Configurable RapidRain Thresholds', gold: true, silver: true, bronze: false },
-    { name: 'Site-Specific Forecasts', gold: true, silver: false, bronze: false },
-    { name: 'On-Demand Lookup', gold: true, silver: false, bronze: false },
+    { name: '24/7 Monitoring', platinum: true, gold: true, silver: true, bronze: true },
+    { name: 'Threshold Notification', platinum: true, gold: true, silver: true, bronze: true },
+    { name: 'National Precipitation Forecast', platinum: true, gold: true, silver: true, bronze: true },
+    { name: 'Daily and Monthly Reports', platinum: true, gold: true, silver: true, bronze: false },
+    { name: 'Previous Month Report Only', platinum: false, gold: false, silver: false, bronze: true },
+    { name: 'Contact Notifications', platinum: true, gold: true, silver: true, bronze: true },
+    { name: 'Excessive Rainfall', platinum: true, gold: true, silver: true, bronze: false },
+    { name: 'RapidRain', platinum: true, gold: true, silver: true, bronze: false },
+    { name: 'Configurable RapidRain Thresholds', platinum: true, gold: true, silver: true, bronze: false },
+    { name: 'Site-Specific Forecasts', platinum: true, gold: true, silver: false, bronze: false },
+    { name: 'On-Demand Lookup', platinum: true, gold: true, silver: false, bronze: false },
+    { name: 'RainIQ', platinum: true, gold: false, silver: false, bronze: false },
   ];
 
   const renderFeatures = (plan) =>
@@ -174,7 +178,24 @@ export default function Prices({ isSmall = false }) {
         </Link>
       )}
 
-      <div className="grid gap-6 md:grid-cols-3">
+      <div className={`grid gap-6 ${showPlatinum ? 'md:grid-cols-4' : 'md:grid-cols-3'}`}>
+        {showPlatinum && (
+          <div className="plan platinum flex flex-col items-center justify-center border border-purple-400 rounded-lg p-6 bg-purple-50 shadow-md">
+            <h3 className="text-xl font-bold text-purple-700 mb-2">Platinum</h3>
+            <p className="text-4xl font-bold text-gray-800 mb-2">$30.00</p>
+            <p className="text-gray-600 text-sm text-center">per 5 locations</p>
+            <ul className="mt-4 space-y-2 text-gray-700">{renderFeatures('platinum')}</ul>
+            {!isSmall && (
+              <button
+                onClick={() => handleUpgrade('platinum')}
+                className="mt-4 px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 transition"
+              >
+                Upgrade
+              </button>
+            )}
+          </div>
+        )}
+
         {/* Gold */}
         <div className="plan gold flex flex-col items-center justify-center border border-yellow-400 rounded-lg p-6 bg-yellow-50 shadow-md">
           <h3 className="text-xl font-bold text-yellow-700 mb-2">Gold</h3>

--- a/src/utility/loginUser.js
+++ b/src/utility/loginUser.js
@@ -197,6 +197,9 @@ const convertTier = (person) =>{
         case "gold":
             tier = 3;
             break;
+        case "platinum":
+            tier = 3;
+            break;
         case "silver":
             tier = 2;
             break;


### PR DESCRIPTION
### Motivation
- Introduce a new Platinum tier that is functionally Gold plus RainIQ and keep the UI/backend behind a feature flag so it can be enabled safely. 
- Provide placeholders (pricing card, checkout wiring, account selection) so the tier can be turned on later without further structural changes.

### Description
- Added a feature-flag guard using `isActive('showPlatinum')` and a new Platinum plan card to the pricing UI (`src/pages/Prices.jsx`) that shows only when the flag is active. 
- Added Platinum as an option in the signup wizard (`src/pages/FormWizardDelayed.tsx`) and the client account form (`src/components/ClientForm.jsx`), both gated by `isActive('showPlatinum')`. 
- Wired `platinum` into the server-side checkout price whitelist (`netlify/functions/create-checkout-session.ts`) via a placeholder `PRICE_ID_PLATINUM` and updated checkout payloads to allow `plan: 'platinum'`. 
- Updated RainIQ entitlement logic (`src/components/RainIQ.jsx`) to grant access for users whose client tier is `platinum` (while keeping `is_superuser` and `isActive('rainIQ')` paths), and updated `convertTier` mapping (`src/utility/loginUser.js`) and signup provisioning defaults to treat `platinum` as the same numeric level as Gold for existing gating logic. 

### Testing
- Ran `npm run build` which completed successfully and produced build artifacts, with unrelated existing JSX warnings from other files. 
- Ran `npm run lint` which failed due to many pre-existing repo-wide lint issues unrelated to these changes and not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf4081c2b4832caf3921c96dd24d2b)