### PR TITLE
Add second GA4 config (G-9QNG1990XF) to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
       gtag('js', new Date());
 
       gtag('config', 'G-X81DT5Q8Z7');
+      gtag('config', 'G-9QNG1990XF');
     </script>
   </head>
   <body>


### PR DESCRIPTION
### Motivation
- Ensure events/pageviews from waterwatchpro25.com are also sent to the marketing GA4 property (`G-9QNG1990XF`) while preserving the existing site-specific property (`G-X81DT5Q8Z7`).

### Description
- Updated `index.html` to add a second `gtag('config', 'G-9QNG1990XF')` immediately after the existing `gtag('config', 'G-X81DT5Q8Z7')`, reusing the same `gtag.js` loader.

### Testing
- Ran verification commands (`git diff -- index.html`, `git add`/`git commit`, and `nl -ba index.html | sed -n '20,45p'`) and they completed successfully, showing the new `gtag('config', 'G-9QNG1990XF')` line in `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb573a5808832c9e090d1741551e50)