### PR TITLE
Move 'Send Monthly Report' toggle to General Settings and Contact notifications

### DIFF
--- a/src/components/ClientForm.jsx
+++ b/src/components/ClientForm.jsx
@@ -270,12 +270,6 @@ const ClientForm = ({ clientToEdit,myself }) => {
           <Toggle checked={JSON.stringify(auto_add_locations) == "true"} onChange={() => setAutoAddLocations(!auto_add_locations)} />
           <span className="ml-2">Auto Add Locations</span>
         </div>
-        {isActive('send_monthly_report') && (
-          <div className=" flex items-center">
-            <Toggle checked={monthly_report_on === true} onChange={() => setMonthlyReportOn(!monthly_report_on)} />
-            <span className="ml-2">Send Monthly Report</span>
-          </div>
-        )}
 
         {/* Account Actions */}
         <div className="border p-4 rounded shadow">

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -32,6 +32,7 @@ const ContactForm = ({  }) => {
 
   const [formData, setFormData] = useState({
     monthly_report_on: contactToEdit ? contactToEdit?.monthly_report_on : true,
+    monthly_report_on_sms: contactToEdit ? contactToEdit?.monthly_report_on_sms : true,
     daily_report_on: contactToEdit ? contactToEdit?.daily_report_on : true,
     daily_report_on_sms: contactToEdit ? contactToEdit?.daily_report_on_sms  : true,
     exceed24h_on: contactToEdit ? contactToEdit?.exceed24h_on : true,
@@ -202,6 +203,7 @@ const ContactForm = ({  }) => {
       
       daily_report_on:formData.daily_report_on,
       monthly_report_on: formData.monthly_report_on,
+      monthly_report_on_sms: formData.monthly_report_on_sms,
       daily_report_on_sms: formData.daily_report_on_sms,
       forecast_on: formData.forecast_on,
       forecast_on_sms:formData.forecast_on_sms,
@@ -297,10 +299,15 @@ const ContactForm = ({  }) => {
   
     return Object.entries(groupedKeys).map(([header, { email, sms }]) => {
       const label = header.replace(/_/g, ' '); // Create a readable header
+      const formattedLabel = label
+        .trim()
+        .replace(/ on$/i, '')
+        .replace("atlas14 24h", "NOAA Atlas 14")
+        .replace("exceed24h", "24 Hour Threshold");
   
       return (
         ( <div className={`flex flex-col mb-4 ${label.toLocaleLowerCase().startsWith("forecast") && convertTier(user) < 3 ? 'hidden' : ''} ${label.toLocaleLowerCase().startsWith("atlas") && convertTier(user) < 2 ? 'hidden' : ''}`} key={header} >
-          <span className="font-bold capitalize">{label.trim().replace("on","").replace("atlas14 24h","NOAA Atlas 14").replace("exceed24h","24 Hour Threshold")}</span>
+          <span className="font-bold capitalize">{formattedLabel}</span>
           
           <div className="flex items-center mt-2">
             <span className="mr-2">Email</span>

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -31,6 +31,7 @@ const ContactForm = ({  }) => {
   const [msg,setMsg] = useState(null)
 
   const [formData, setFormData] = useState({
+    monthly_report_on: contactToEdit ? contactToEdit?.monthly_report_on : true,
     daily_report_on: contactToEdit ? contactToEdit?.daily_report_on : true,
     daily_report_on_sms: contactToEdit ? contactToEdit?.daily_report_on_sms  : true,
     exceed24h_on: contactToEdit ? contactToEdit?.exceed24h_on : true,
@@ -200,6 +201,7 @@ const ContactForm = ({  }) => {
       status: 'active',
       
       daily_report_on:formData.daily_report_on,
+      monthly_report_on: formData.monthly_report_on,
       daily_report_on_sms: formData.daily_report_on_sms,
       forecast_on: formData.forecast_on,
       forecast_on_sms:formData.forecast_on_sms,
@@ -308,13 +310,15 @@ const ContactForm = ({  }) => {
             />
           </div>
   
-          <div className="flex items-center mt-2">
-            <span className="mr-2">Text</span>
-            <Toggle
-              checked={settings[sms]}
-              onChange={() => handleChange({ name: sms, value: !settings[sms] })}
-            />
-          </div>
+          {sms && (
+            <div className="flex items-center mt-2">
+              <span className="mr-2">Text</span>
+              <Toggle
+                checked={settings[sms]}
+                onChange={() => handleChange({ name: sms, value: !settings[sms] })}
+              />
+            </div>
+          )}
         </div>)
       );
     });

--- a/src/pages/GeneralSettings.jsx
+++ b/src/pages/GeneralSettings.jsx
@@ -62,7 +62,8 @@ const GeneralSettingsPage = () => {
           exceed24h_combine_locations: response.data.exceed24h_combine_locations || false,
           rapidrain_on: response.data.rapidrain_on || false,
           rapidrain_combine_locations: response.data.rapidrain_combine_locations || false,
-          rapidrain_first_on: response.data.rapidrain_first_on || false
+          rapidrain_first_on: response.data.rapidrain_first_on || false,
+          monthly_report_on: response.data.monthly_report_on || false
         });
       } catch (error) {
         console.error('Error fetching client data:', error.message);
@@ -187,6 +188,20 @@ const GeneralSettingsPage = () => {
                 <span className="ml-4">Combine Locations</span>
               </div>
               
+            </div>
+
+            <div className="border p-6 rounded shadow-md">
+              <h2 className="text-xl font-bold mb-4">Monthly Report</h2>
+              <div className="flex items-center mb-4 gap-2">
+                <Toggle
+                  checked={settings.monthly_report_on}
+                  onChange={() => handleToggle('monthly_report_on')}
+                />
+                <span>Send Monthly Report</span>
+              </div>
+              <div className='ml-[56px] mb-2'>
+                All contacts will receive a monthly summary report.
+              </div>
             </div>
 
             {/* 24 Hour Threshold Section */}


### PR DESCRIPTION
### Motivation
- Centralize control for the monthly summary report so account-wide enabling lives in Settings rather than the client form, while still allowing per-contact overrides in the contact notifications UI.
- Ensure the contact notification form and API payload include the monthly setting so individual contacts can opt in/out independently of the account-wide setting.

### Description
- Removed the `Send Monthly Report` toggle from the client form UI in `src/components/ClientForm.jsx` so it is no longer editable on the client form page.
- Added `monthly_report_on` to settings state hydration and a new "Monthly Report" section with a `Toggle` on `src/pages/GeneralSettings.jsx` so accounts can control the feature from General Settings.
- Added `monthly_report_on` to contact-level `formData` and included it in the contact save `payload` in `src/components/ContactForm.jsx` so contacts can override the account setting.
- Updated notification rendering in `src/components/ContactForm.jsx` to support notification keys that only have an email toggle (no SMS companion), preventing rendering errors for alerts that lack an `_sms` key.

### Testing
- Ran `npm run -s build`, which completed successfully and produced a production build.
- The build output included pre-existing unrelated JSX/esbuild warnings in other files, but the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a595e130832ca90c4268b8a63299)