### PR TITLE
Make PDF reports email-only on Reports page

### DIFF
--- a/src/components/Reports.jsx
+++ b/src/components/Reports.jsx
@@ -489,7 +489,7 @@ const Reports = () => {
 
     setShowDialog(true);
     const baseQuery = query;
-    if ( (selectedLocations.length > 1 || displayFormat === 'csv' ||  displayFormat == 'excel') ) {
+    if ( (selectedLocations.length > 1 || displayFormat === 'csv' ||  displayFormat == 'excel' || displayFormat === 'pdf') ) {
       // POST Request for multiple locations
 
 
@@ -888,7 +888,7 @@ const Reports = () => {
             type="submit"
             className="bg-green-500 text-white px-6 py-2 rounded hover:bg-green-600"
           >
-            {selectedLocations.length > 1 || displayFormat == "csv"  || displayFormat == "excel" ? "Email Report" : "View Report"}
+            {selectedLocations.length > 1 || displayFormat == "csv"  || displayFormat == "excel" || displayFormat == "pdf" ? "Email Report" : "View Report"}
           </button>
         </div>
       </form>


### PR DESCRIPTION
### Motivation
- Ensure PDF reports follow the same email-only submission flow as CSV/Excel and prevent a single-location HTML view for PDFs.

### Description
- Updated `src/components/Reports.jsx` to include `displayFormat === 'pdf'` in the POST/email-job branch so PDFs always use the email job flow and also adjusted the submit button condition to display "Email Report" when `displayFormat === 'pdf'`.

### Testing
- Performed a diff review and committed the change, and a quick `npm` test probe (`npm -s run -q test -- --help`) exited non-zero so the automated test suite was not validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041af60a68832c97cba51a8ebddd70)