### PR TITLE
Gate monthly report UI behind send_monthly_report feature flag

### DIFF
--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux';
 import WorkingDialog from './WorkingDialog';
 import { convertTier } from '../utility/loginUser';
 import {validateEmail} from '../utility/passwordFunc'
+import { useFeatureFlags } from '@geejay/use-feature-flags';
 import {
   isValidPhoneNumber,
   PHONE_INPUT_PATTERN,
@@ -57,6 +58,8 @@ const ContactForm = ({  }) => {
 
   const [isAlertSettingsExpanded, setIsAlertSettingsExpanded] = useState(true);
   const user = useSelector((state) => state.userInfo.user);
+  const { isActive } = useFeatureFlags();
+  const isSendMonthlyReportEnabled = isActive('send_monthly_report');
 
   //alert(`Contact Form Received ${contactToEdit?.user_id} ${contactToEdit.name}`)
   
@@ -286,7 +289,9 @@ const ContactForm = ({  }) => {
 
   const renderSettings = (settings) => {
     // Group the keys into pairs (email + SMS)
-    const groupedKeys = Object.keys(settings).reduce((acc, key) => {
+    const groupedKeys = Object.keys(settings)
+      .filter((key) => isSendMonthlyReportEnabled || !key.startsWith('monthly_report_on'))
+      .reduce((acc, key) => {
       const baseKey = key.replace('_sms', '');
       if (!acc[baseKey]) acc[baseKey] = {};
       if (key.endsWith('_sms')) {

--- a/src/pages/GeneralSettings.jsx
+++ b/src/pages/GeneralSettings.jsx
@@ -17,6 +17,7 @@ const GeneralSettingsPage = () => {
   const { state } = useLocation();
   const { isActive } = useFeatureFlags();
   const isCustomDailyReportTimeEnabled = isActive('customDailyReportTime');
+  const isSendMonthlyReportEnabled = isActive('send_monthly_report');
   const navigate = useNavigate();
   const user = useSelector((state) => state.userInfo.user);
   const [settings, setSettings] = useState({});
@@ -190,6 +191,7 @@ const GeneralSettingsPage = () => {
               
             </div>
 
+            {isSendMonthlyReportEnabled && (
             <div className="border p-6 rounded shadow-md">
               <h2 className="text-xl font-bold mb-4">Monthly Report</h2>
               <div className="flex items-center mb-4 gap-2">
@@ -203,6 +205,7 @@ const GeneralSettingsPage = () => {
                 All contacts will receive a monthly summary report.
               </div>
             </div>
+            )}
 
             {/* 24 Hour Threshold Section */}
             <div className="border p-6 rounded shadow-md flex flex-col gap-2">


### PR DESCRIPTION
### Motivation
- Limit exposure of the "Send Monthly Report" option to users/clients only when the `send_monthly_report` feature flag is enabled.

### Description
- Added feature-flag evaluation via `useFeatureFlags()` and a local `isSendMonthlyReportEnabled` variable in `src/pages/GeneralSettings.jsx` and `src/components/ContactForm.jsx`.
- Wrapped the Monthly Report card on the Settings > General page in a conditional render: `isSendMonthlyReportEnabled && (...)` in `src/pages/GeneralSettings.jsx`.
- In `src/components/ContactForm.jsx` imported `useFeatureFlags` and filtered alert-setting keys with `.filter((key) => isSendMonthlyReportEnabled || !key.startsWith('monthly_report_on'))` so monthly-report toggles are omitted from the contact form UI when the flag is off.
- UI-only change: payload fields and API interactions remain unchanged.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041ea5638c832cb190d010e3aaab2a)