### PR TITLE
Add `free4All` feature flag for RainIQ menu visibility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,7 +76,8 @@ function App() {
 
   const featureFlagKey = import.meta.env.VITE_GEEJAY_FEATURE_FLAGS || import.meta.env.GEEJAY_FEATURE_FLAGS || "aaba70cc-6ed2-4acf-a4c7-74c9e860fc75";
   const {isActive,loading} = useFeatureFlags(featureFlagKey)
-  const canViewRainIQMenu = isActive('rainIQ') && RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
+  const canViewRainIQByEmail = RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
+  const canViewRainIQMenu = isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
 
   const handleThemeToggle = () => {
     if (isActive('dark-mode')) {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -46,7 +46,8 @@ export default function Header({ theme, onToggleTheme }) {
   
   const {isActive} = useFeatureFlags()
 
-  const canViewRainIQMenu = isActive('rainIQ') && user.role !== "admin" && RAINIQ_ALLOWED_EMAILS.includes((user.email || "").toLowerCase());
+  const canViewRainIQByEmail = user.role !== "admin" && RAINIQ_ALLOWED_EMAILS.includes((user.email || "").toLowerCase());
+  const canViewRainIQMenu = isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
 
   
 


### PR DESCRIPTION
### Motivation
- Make the RainIQ menu option showable to everyone via a feature flag instead of only when the logged-in email matches an allowlist, while keeping the existing `rainIQ` feature flag required.
- Keep existing allowlist behavior as a fallback so operators can toggle broad access with `free4All` without changing the list of allowed emails.

### Description
- Added a `canViewRainIQByEmail` helper and updated `canViewRainIQMenu` to `isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail)` in `src/components/Header.jsx` so header navigation respects the new `free4All` flag while preserving the admin/email checks.
- Applied the same change in `src/App.jsx` so the app-side menu and header remain consistent in their RainIQ visibility logic.

### Testing
- Ran the production build with `npm run -s build` which completed successfully and produced the production bundle.
- The build emitted unrelated JSX warnings from other files but the build finished without failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0681a822e0832c9413838f5fec52fc)