### PR TITLE
Hide monthly report SMS toggle in contact form

### DIFF
--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -322,7 +322,7 @@ const ContactForm = ({  }) => {
             />
           </div>
   
-          {sms && (
+          {sms && sms !== 'monthly_report_on_sms' && (
             <div className="flex items-center mt-2">
               <span className="mr-2">Text</span>
               <Toggle


### PR DESCRIPTION
### Motivation
- Temporarily hide the SMS/Text toggle for the monthly report option in the contact form UI because monthly-report SMS will be implemented later.

### Description
- Add a guard in `renderSettings` in `src/components/ContactForm.jsx` so the SMS toggle is only rendered when `sms` exists and is not `monthly_report_on_sms` (`{sms && sms !== 'monthly_report_on_sms' && (...)}`).

### Testing
- Located the notification keys with `rg` and inspected the changed lines using `nl -ba src/components/ContactForm.jsx | sed -n '315,345p'`, which confirmed the `sms !== 'monthly_report_on_sms'` condition is present and the Text toggle is omitted for the monthly report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077fc5b1f8832cbe52775b9019faf1)