### PR TITLE
Update RainIQ UI/PDF labels and detail visibility

### DIFF
--- a/src/components/RainIQ.jsx
+++ b/src/components/RainIQ.jsx
@@ -970,7 +970,7 @@ export default function RainIQ() {
 
           <div class="metrics-grid">${metricsHtml}</div>
 
-          <h3>Supporting table</h3>
+          <h3>${escapeHtml(selectedQueryLabel)}</h3>
           <table>
             <thead>
               <tr>${locationResult.columns.map((column) => `<th>${escapeHtml(column)}</th>`).join('')}</tr>

--- a/src/components/RainIQ.jsx
+++ b/src/components/RainIQ.jsx
@@ -146,7 +146,7 @@ const mockResponses = {
     metrics: [
       { label: 'Threshold', value: '0.5 in' },
       { label: 'Qualifying events', value: '8' },
-      { label: 'Most intense event', value: '1.22 in on 01/23/2026' },
+      { label: 'Maximum event', value: '1.22 in on 01/23/2026' },
     ],
     columns: ['Date', '24-hour Rainfall (in)', 'Qualified'],
     rows: [
@@ -649,7 +649,7 @@ export default function RainIQ() {
             { label: 'Threshold', value: `${effectiveThreshold.toFixed(2)} in` },
             { label: 'Qualifying events', value: String(qualifyingRows.length) },
             {
-              label: 'Most intense event',
+              label: 'Maximum event',
               value: mostIntenseEvent?.date
                 ? `${Number(mostIntenseEvent.daily_total || 0).toFixed(2)} in on ${formatDateForUi(mostIntenseEvent.date)}`
                 : 'N/A',
@@ -902,7 +902,7 @@ export default function RainIQ() {
 
     const querySpecificDailyTotalsLabel = {
       wettestMonth: 'Daily totals',
-      avgMonthly: 'Daily totals',
+      avgMonthly: 'Daily detail',
       avgDaily: 'Daily totals',
       qualifyingEvents: 'Daily totals',
       largest24h: 'Daily totals',
@@ -977,11 +977,6 @@ export default function RainIQ() {
             </thead>
             <tbody>${summaryRowsHtml}</tbody>
           </table>
-
-          <h3>Supporting chart</h3>
-          <div class="bar-chart">
-            ${chartBarsHtml || '<p>No chart data available.</p>'}
-          </div>
 
           <h3>${escapeHtml(querySpecificDailyTotalsLabel)}</h3>
           <table>
@@ -1447,17 +1442,15 @@ export default function RainIQ() {
           </p>
         </div>
         <div className="mt-4 flex items-center gap-3">
-          <label htmlFor="detailed-view-toggle" className="text-sm font-semibold text-slate-700 dark:text-slate-200">
-            Detailed view
-          </label>
           <input
             id="detailed-view-toggle"
             type="checkbox"
             checked={showDetailedView}
             onChange={(event) => setShowDetailedView(event.target.checked)}
+            className="h-5 w-5"
           />
-          <span className="text-xs text-slate-500">
-            {showDetailedView ? 'On: show summary + chart details.' : 'Off: show summary cards only.'}
+          <span className="text-xl font-semibold text-slate-700 dark:text-slate-200">
+            Show specific dates and detail.
           </span>
         </div>
 
@@ -1544,7 +1537,7 @@ export default function RainIQ() {
                     </div>
 
                     <div className="rounded-lg border p-4">
-                      <h4 className="mb-3 text-lg font-semibold">Monthly rainfall totals</h4>
+                      <h4 className="mb-3 text-lg font-semibold">Rainfall totals</h4>
                       <div className="space-y-3">
                         {locationResult.chart.map((item) => (
                           <div key={`${locationResult.id}-${item.label}`}>


### PR DESCRIPTION
### Motivation
- Clarify metric wording for the qualifying-events query and make the detailed-view control more visually prominent and descriptive.
- Simplify the on-page chart header by removing the word "Monthly" to match updated wording.
- Temporarily hide the PDF supporting chart and adjust PDF section labels to match the updated UI copy.

### Description
- Renamed the qualifying-events metric label from `Most intense event` to `Maximum event` in both the mock responses and runtime metric rendering in `src/components/RainIQ.jsx`.
- Reworked the detailed-view control by removing the separate "Detailed view" label, enlarging the checkbox (`className="h-5 w-5"`), and replacing the helper text with a larger, bolder string `Show specific dates and detail.`.
- Renamed the in-page header `Monthly rainfall totals` to `Rainfall totals` in the detailed chart card.
- Removed the "Supporting chart" block from the PDF export HTML generation so the chart section is not rendered in the PDF output.
- Changed the PDF daily section label for the `avgMonthly` query from `Daily totals` to `Daily detail`.

### Testing
- Ran `npm run lint`; linting failed due to many pre-existing repository-wide issues not introduced by this change, and no new lint failures attributable to the modified lines were observed.
- Performed local code inspection of `src/components/RainIQ.jsx` to verify the updated labels, PDF HTML template, and the detailed-view control rendering behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ae6228ec832c86e2fd0aa554db11)