### PR TITLE
Temporarily hide Monthly Report option in General Settings

### DIFF
--- a/src/pages/GeneralSettings.jsx
+++ b/src/pages/GeneralSettings.jsx
@@ -18,6 +18,7 @@ const GeneralSettingsPage = () => {
   const { isActive } = useFeatureFlags();
   const isCustomDailyReportTimeEnabled = isActive('customDailyReportTime');
   const isSendMonthlyReportEnabled = isActive('send_monthly_report');
+  const showMonthlyReportSection = false;
   const navigate = useNavigate();
   const user = useSelector((state) => state.userInfo.user);
   const [settings, setSettings] = useState({});
@@ -191,7 +192,7 @@ const GeneralSettingsPage = () => {
               
             </div>
 
-            {isSendMonthlyReportEnabled && (
+            {isSendMonthlyReportEnabled && showMonthlyReportSection && (
             <div className="border p-6 rounded shadow-md">
               <h2 className="text-xl font-bold mb-4">Monthly Report</h2>
               <div className="flex items-center mb-4 gap-2">


### PR DESCRIPTION
### Motivation
- Temporarily remove the Monthly Report UI from the account-level notification settings page while preserving the underlying feature and keeping the Monthly Report behavior active elsewhere.

### Description
- In `src/pages/GeneralSettings.jsx` added `const showMonthlyReportSection = false;` and changed the Monthly Report render guard from `isSendMonthlyReportEnabled && (` to `isSendMonthlyReportEnabled && showMonthlyReportSection && (` so the section is hidden without modifying `monthly_report_on` state or `src/components/ContactForm.jsx`.

### Testing
- Ran `npm run lint -- src/pages/GeneralSettings.jsx`, which failed due to many pre-existing lint issues across the repository and did not reveal any new, targeted errors introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cd2b5b48832c9889b27c86637e4e)