### PR TITLE
Hide RainIQ menu option for admin users

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,8 +76,8 @@ function App() {
 
   const featureFlagKey = import.meta.env.VITE_GEEJAY_FEATURE_FLAGS || import.meta.env.GEEJAY_FEATURE_FLAGS || "aaba70cc-6ed2-4acf-a4c7-74c9e860fc75";
   const {isActive,loading} = useFeatureFlags(featureFlagKey)
-  const canViewRainIQByEmail = RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
-  const canViewRainIQMenu = isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
+  const canViewRainIQByEmail = user.role !== "admin" && RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
+  const canViewRainIQMenu = user.role !== "admin" && isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
 
   const handleThemeToggle = () => {
     if (isActive('dark-mode')) {


### PR DESCRIPTION
### Motivation
- Prevent admin users from seeing the RainIQ menu option even when feature flags or allow-listed emails would otherwise enable it.

### Description
- Add an admin-role guard in `src/App.jsx` by requiring `user.role !== "admin"` for both `canViewRainIQByEmail` and `canViewRainIQMenu` so admins do not see the RainIQ link.

### Testing
- Ran `npm run lint` which failed due to existing, unrelated lint errors across the project.
- Ran `npm run build` which completed successfully and produced a production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b53154714832cbf64cd40b00317fd)