### PR TITLE
Hide RainIQ menu for contacts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,7 +77,7 @@ function App() {
   const featureFlagKey = import.meta.env.VITE_GEEJAY_FEATURE_FLAGS || import.meta.env.GEEJAY_FEATURE_FLAGS || "aaba70cc-6ed2-4acf-a4c7-74c9e860fc75";
   const {isActive,loading} = useFeatureFlags(featureFlagKey)
   const canViewRainIQByEmail = RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
-  const canViewRainIQMenu = isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
+  const canViewRainIQMenu = user.role !== 'contact' && isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
 
   const handleThemeToggle = () => {
     if (isActive('dark-mode')) {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -47,7 +47,7 @@ export default function Header({ theme, onToggleTheme }) {
   const {isActive} = useFeatureFlags()
 
   const canViewRainIQByEmail = user.role !== "admin" && RAINIQ_ALLOWED_EMAILS.includes((user.email || "").toLowerCase());
-  const canViewRainIQMenu = isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
+  const canViewRainIQMenu = user.role !== 'contact' && isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
 
   
 


### PR DESCRIPTION
### Motivation
- Prevent users with the `contact` role from seeing the RainIQ menu/link in both the mobile slide-out menu and the desktop header.

### Description
- Add a `user.role !== 'contact'` guard to the `canViewRainIQMenu` calculation in `src/App.jsx` and `src/components/Header.jsx` so RainIQ links are omitted for contact users.

### Testing
- Ran `npm run build` and the production build completed successfully (with standard warnings about bundle size and browserslist). 
- Ran `npm run lint` which failed due to existing repository-wide lint/parsing errors unrelated to this change. 
- Ran `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da7e91ce8832caff964b59f13dd1f)