### PR TITLE
Hide RainIQ nav for bronze-tier users (replace contact role check)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,7 +77,8 @@ function App() {
   const featureFlagKey = import.meta.env.VITE_GEEJAY_FEATURE_FLAGS || import.meta.env.GEEJAY_FEATURE_FLAGS || "aaba70cc-6ed2-4acf-a4c7-74c9e860fc75";
   const {isActive,loading} = useFeatureFlags(featureFlagKey)
   const canViewRainIQByEmail = RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
-  const canViewRainIQMenu = user.role !== 'contact' && isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
+  const isBronzeRainIQTier = user.clients?.[0]?.tier?.toLowerCase() === 'bronze';
+  const canViewRainIQMenu = !isBronzeRainIQTier && isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
 
   const handleThemeToggle = () => {
     if (isActive('dark-mode')) {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -47,7 +47,8 @@ export default function Header({ theme, onToggleTheme }) {
   const {isActive} = useFeatureFlags()
 
   const canViewRainIQByEmail = user.role !== "admin" && RAINIQ_ALLOWED_EMAILS.includes((user.email || "").toLowerCase());
-  const canViewRainIQMenu = user.role !== 'contact' && isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
+  const isBronzeRainIQTier = user.clients?.[0]?.tier?.toLowerCase() === 'bronze';
+  const canViewRainIQMenu = !isBronzeRainIQTier && isActive('rainIQ') && (isActive('free4All') || canViewRainIQByEmail);
 
   
 


### PR DESCRIPTION
### Motivation
- Replace the existing nav visibility rule that excluded users by role (`contact`) with a tier-based rule so RainIQ is hidden for bronze-tier accounts.

### Description
- Updated nav visibility in `src/App.jsx` to compute `isBronzeRainIQTier` from `user.clients[0]?.tier` and require `!isBronzeRainIQTier` for `canViewRainIQMenu` instead of excluding the `contact` role.
- Made the same change in `src/components/Header.jsx` so both mobile and desktop navs hide RainIQ when the active client tier is `bronze`.
- No other behavior or feature flags were changed; the `RAINIQ_ALLOWED_EMAILS` and feature-flag checks remain in place.

### Testing
- Ran `npm run build` which completed successfully and produced a production build.
- Ran `npm run lint` which failed due to many pre-existing lint and parsing errors across the repository that are unrelated to this change. No new lint errors were introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e2282c138832c9e6287c2e5804109)