### PR TITLE
Hide RainIQ Advanced Analytics for Bronze-tier users

### DIFF
--- a/src/components/RainIQ.jsx
+++ b/src/components/RainIQ.jsx
@@ -417,35 +417,45 @@ export default function RainIQ() {
     }
   };
 
+  const userTier = user?.clients?.[0]?.tier?.toLowerCase();
+  const isBronzeTier = userTier === 'bronze';
+
   const canAccessRainIQ = useMemo(() => {
-    const userTier = user?.clients?.[0]?.tier?.toLowerCase();
     return userTier === 'platinum' || user.is_superuser || isActive('rainIQ');
-  }, [user, isActive]);
-const canViewRainIQByEmail = RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
+  }, [user, userTier, isActive]);
+
+  const canViewRainIQByEmail = RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
+  const last4ReportsActive = isActive('last4Reports');
+  const canViewAdvancedEventAnalytics = !isBronzeTier && (last4ReportsActive || canViewRainIQByEmail);
+
   const reportOptions = useMemo(() => {
-    const showAllOptions = isActive('last4Reports') || canViewRainIQByEmail;
-    if (showAllOptions) {
-      return groupedQueries;
-    }
+    const showAllOptions = canViewAdvancedEventAnalytics;
 
     return Object.entries(groupedQueries).reduce((acc, [group, groupQueries]) => {
-      const filtered = groupQueries.filter((query) => !last4ReportQueryValues.includes(query.value));
+      const filtered = groupQueries.filter((query) => {
+        const isAdvancedEventAnalyticsQuery = last4ReportQueryValues.includes(query.value);
+
+        if (isBronzeTier && isAdvancedEventAnalyticsQuery) {
+          return false;
+        }
+
+        return showAllOptions || !isAdvancedEventAnalyticsQuery;
+      });
+
       if (filtered.length) {
         acc[group] = filtered;
       }
       return acc;
     }, {});
-  }, [isActive]);
+  }, [canViewAdvancedEventAnalytics, isBronzeTier]);
 
   useEffect(() => {
-    if (isActive('last4Reports')) {
-      return;
-    }
+    const selectedQueryIsAdvancedEventAnalytics = last4ReportQueryValues.includes(selectedQuery);
 
-    if (last4ReportQueryValues.includes(selectedQuery)) {
+    if (selectedQueryIsAdvancedEventAnalytics && !canViewAdvancedEventAnalytics) {
       setSelectedQuery('avgDaily');
     }
-  }, [isActive, selectedQuery]);
+  }, [canViewAdvancedEventAnalytics, selectedQuery]);
 
   const customRangeError = useMemo(() => {
     if (selectedRange !== 'custom') {


### PR DESCRIPTION
### Motivation
- Prevent bronze-tier clients from seeing or selecting Advanced Event Analytics queries on the RainIQ screen.
- Ensure a consistent UI state by resetting any already-selected advanced query when a user becomes ineligible.

### Description
- Updated `src/components/RainIQ.jsx` to compute `userTier` and `isBronzeTier` and to expose `canViewAdvancedEventAnalytics` that gates access to advanced queries.
- Filtered `reportOptions` to remove queries in `last4ReportQueryValues` for bronze-tier users while preserving the existing `last4Reports` and allowed-email behavior for non-bronze users.
- Added an effect that resets `selectedQuery` to `avgDaily` when the currently selected query is an advanced-event query and the user can no longer view advanced analytics, and adjusted hook dependency arrays accordingly.

### Testing
- Ran `npx eslint src/components/RainIQ.jsx`, which completed successfully with an existing hook dependency warning.
- Ran `npm run lint`, which failed due to pre-existing repository-wide lint/parsing issues unrelated to this change.
- Ran `npm run build` (Vite production build), which succeeded with existing JSX transform and chunk-size warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e475d33f4832caa95712637e02dab)