### PR TITLE
Update RainIQ access labels on upgrades page

### DIFF
--- a/src/pages/Prices.jsx
+++ b/src/pages/Prices.jsx
@@ -155,7 +155,7 @@ export default function Prices({ isSmall = false }) {
   const renderFeatureLabel = (feature, plan) => {
     if (feature.name === 'RainIQ') {
       return (
-        <span className="flex items-center gap-2">
+        <span className="flex items-end gap-1">
           <img src="/rainiq-logo.png" alt="RainIQ" className="h-6 w-auto" />
           <span>{feature[plan]}</span>
         </span>
@@ -197,7 +197,7 @@ export default function Prices({ isSmall = false }) {
             <h3 className="text-xl font-bold text-purple-700 mb-2">Platinum</h3>
             <p className="text-4xl font-bold text-gray-800 mb-2">$30.00</p>
             <p className="text-gray-600 text-sm text-center">per 5 locations</p>
-            <ul className="mt-4 space-y-2 text-gray-700">{renderFeatures('platinum')}</ul>
+            <ul className="mt-4 space-y-4 text-gray-700">{renderFeatures('platinum')}</ul>
             {!isSmall && (
               <button
                 onClick={() => handleUpgrade('platinum')}
@@ -214,7 +214,7 @@ export default function Prices({ isSmall = false }) {
           <h3 className="text-xl font-bold text-yellow-700 mb-2">Gold</h3>
           <p className="text-4xl font-bold text-gray-800 mb-2">$24.00</p>
           <p className="text-gray-600 text-sm text-center">per 5 locations</p>
-          <ul className="mt-4 space-y-2 text-gray-700">{renderFeatures('gold')}</ul>
+          <ul className="mt-4 space-y-4 text-gray-700">{renderFeatures('gold')}</ul>
           {!isSmall && (
             <button
               onClick={() => handleUpgrade('gold')}
@@ -230,7 +230,7 @@ export default function Prices({ isSmall = false }) {
           <h3 className="text-xl font-bold text-gray-700 mb-2">Silver</h3>
           <p className="text-4xl font-bold text-gray-800 mb-2">$18.00</p>
           <p className="text-gray-600 text-sm text-center">per 5 locations</p>
-          <ul className="mt-4 space-y-2 text-gray-700">{renderFeatures('silver')}</ul>
+          <ul className="mt-4 space-y-4 text-gray-700">{renderFeatures('silver')}</ul>
           {!isSmall && (
             <button
               onClick={() => handleUpgrade('silver')}
@@ -246,7 +246,7 @@ export default function Prices({ isSmall = false }) {
           <h3 className="text-xl font-bold text-orange-700 mb-2">Bronze</h3>
           <p className="text-4xl font-bold text-gray-800 mb-2">$12.00</p>
           <p className="text-gray-600 text-sm text-center">per 5 locations</p>
-          <ul className="mt-4 space-y-2 text-gray-700">{renderFeatures('bronze')}</ul>
+          <ul className="mt-4 space-y-4 text-gray-700">{renderFeatures('bronze')}</ul>
           {!isSmall && (
             <button
               onClick={() => handleUpgrade('bronze')}

--- a/src/pages/Prices.jsx
+++ b/src/pages/Prices.jsx
@@ -149,15 +149,28 @@ export default function Prices({ isSmall = false }) {
     { name: 'Configurable RapidRain Thresholds', platinum: true, gold: true, silver: true, bronze: false },
     { name: 'Site-Specific Forecasts', platinum: true, gold: true, silver: false, bronze: false },
     { name: 'On-Demand Lookup', platinum: true, gold: true, silver: false, bronze: false },
-    { name: 'RainIQ', platinum: true, gold: false, silver: false, bronze: false },
+    { name: 'RainIQ', platinum: 'Full Access', gold: 'Limited Access', silver: 'Limited Access', bronze: false },
   ];
+
+  const renderFeatureLabel = (feature, plan) => {
+    if (feature.name === 'RainIQ') {
+      return (
+        <span className="flex items-center gap-2">
+          <img src="/rainiq-logo.png" alt="RainIQ" className="h-6 w-auto" />
+          <span>{feature[plan]}</span>
+        </span>
+      );
+    }
+
+    return <span>{feature.name}</span>;
+  };
 
   const renderFeatures = (plan) =>
     features.map((feature, idx) =>
       feature[plan] ? (
         <li key={idx} className="flex items-center space-x-2">
           <span className="text-green-500 font-bold">✔</span>
-          <span>{feature.name}</span>
+          {renderFeatureLabel(feature, plan)}
         </li>
       ) : null
     );

--- a/src/pages/Prices.jsx
+++ b/src/pages/Prices.jsx
@@ -138,6 +138,7 @@ export default function Prices({ isSmall = false }) {
   }, [location.search, isSmall, dispatch, navigate, user]);
 
   const features = [
+    { name: 'RainIQ', platinum: 'Full Access', gold: 'Limited Access', silver: 'Limited Access', bronze: false },
     { name: '24/7 Monitoring', platinum: true, gold: true, silver: true, bronze: true },
     { name: 'Threshold Notification', platinum: true, gold: true, silver: true, bronze: true },
     { name: 'National Precipitation Forecast', platinum: true, gold: true, silver: true, bronze: true },
@@ -149,7 +150,6 @@ export default function Prices({ isSmall = false }) {
     { name: 'Configurable RapidRain Thresholds', platinum: true, gold: true, silver: true, bronze: false },
     { name: 'Site-Specific Forecasts', platinum: true, gold: true, silver: false, bronze: false },
     { name: 'On-Demand Lookup', platinum: true, gold: true, silver: false, bronze: false },
-    { name: 'RainIQ', platinum: 'Full Access', gold: 'Limited Access', silver: 'Limited Access', bronze: false },
   ];
 
   const renderFeatureLabel = (feature, plan) => {


### PR DESCRIPTION
### Motivation
- Ensure the RainIQ row on the upgrades/pricing page displays the RainIQ logo and the correct access label text so Platinum shows `Full Access` and Gold/Silver show `Limited Access`.

### Description
- Update the `features` entry in `src/pages/Prices.jsx` for `RainIQ` to store plan-specific label strings and add a `renderFeatureLabel` helper that renders the `/rainiq-logo.png` image followed by the access label; `renderFeatures` now uses this helper.
- Only `src/pages/Prices.jsx` was changed to implement this presentation update.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm run lint` which failed due to pre-existing repository-wide lint errors unrelated to this change, and ran `git diff --check` which reported no whitespace issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351326e82c832caaf7ec18bdbf1fa0)