### PR TITLE
Add feature flag to show upgrade gate for Bronze users on RainIQ

### DIFF
--- a/src/components/RainIQ.jsx
+++ b/src/components/RainIQ.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useFeatureFlags } from '@geejay/use-feature-flags';
 import api from '../utility/api';
+import Upgrade from './Upgrade';
 import { VITE_SOCKETLABS_FROM_EMAIL,RAINIQ_ALLOWED_EMAILS } from '../utility/constants';
 
 import fetchByPage from '../utility/fetchByPage';
@@ -475,6 +476,7 @@ export default function RainIQ() {
 
   const canViewRainIQByEmail = RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
   const last4ReportsActive = isActive('last4Reports');
+  const isRainIQBronzeUpgradeBlocked = isBronzeTier && isActive('blockUpgradeRainIQBronze');
   const canViewAdvancedEventAnalytics = !isBronzeTier && (last4ReportsActive || canViewRainIQByEmail);
 
   const reportOptions = useMemo(() => {
@@ -1613,6 +1615,10 @@ export default function RainIQ() {
   const primaryHeadline = !hasExecutedQuery
     ? 'Select criteria and click Analyze to view rainfall trends.'
     : (selectedLocationResults[0]?.headline || 'Run a query to view rainfall insights for this location.');
+
+  if (isRainIQBronzeUpgradeBlocked) {
+    return <Upgrade tier={2}><></></Upgrade>;
+  }
 
   if (!canAccessRainIQ) {
     return (


### PR DESCRIPTION
### Motivation
- Ensure bronze-tier users see the same service-level upgrade UX when attempting to access RainIQ as they do for the NOAA Atlas 14 dashboard tab. 
- Provide an opt-in feature flag to control whether bronze users are blocked from navigating directly to the RainIQ page.

### Description
- Added an `import Upgrade from './Upgrade'` to `src/components/RainIQ.jsx` and introduced the `blockUpgradeRainIQBronze` feature-flag check.
- Computed `isRainIQBronzeUpgradeBlocked` as `isBronzeTier && isActive('blockUpgradeRainIQBronze')` and short-circuited the RainIQ render to return the `Upgrade` component when true, reusing the existing upgrade message markup.
- Preserved existing `canAccessRainIQ` logic so platinum, superusers, and users enabled via the `rainIQ` flag remain unaffected when the new flag is disabled.

### Testing
- Ran `npm run build`, which succeeded and produced a production build.
- Ran `npm run lint`, which failed due to pre-existing repository-wide lint and parsing errors unrelated to this change (e.g., JSX parsing issues in other pages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351b65e9c0832c88d62ffa9368f49e)