### PR TITLE
Gate RainIQ on pricing behind `showPlatinum` feature flag

### DIFF
--- a/src/pages/Prices.jsx
+++ b/src/pages/Prices.jsx
@@ -138,7 +138,9 @@ export default function Prices({ isSmall = false }) {
   }, [location.search, isSmall, dispatch, navigate, user]);
 
   const features = [
-    { name: 'RainIQ', platinum: 'Full Access', gold: 'Limited Access', silver: 'Limited Access', bronze: false },
+    ...(showPlatinum
+      ? [{ name: 'RainIQ', platinum: 'Full Access', gold: 'Limited Access', silver: 'Limited Access', bronze: false }]
+      : []),
     { name: '24/7 Monitoring', platinum: true, gold: true, silver: true, bronze: true },
     { name: 'Threshold Notification', platinum: true, gold: true, silver: true, bronze: true },
     { name: 'National Precipitation Forecast', platinum: true, gold: true, silver: true, bronze: true },


### PR DESCRIPTION
### Motivation
- Only show the RainIQ row on the upgrades/pricing page when the existing `showPlatinum` feature flag is enabled so feature visibility matches tier gating elsewhere.

### Description
- Modify `src/pages/Prices.jsx` to prepend the `RainIQ` entry into the `features` array only when `showPlatinum` (from `isActive('showPlatinum')`) is true, preserving the existing Platinum/Gold/Silver labels and render logic.

### Testing
- Ran `npm run build` which completed successfully; `npm run lint` was run and reported repository-wide lint errors unrelated to this change and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3539f5cd74832c82f998989821ed7a)