### PR TITLE
Add GO_LIVE_2027 feature flag to limit RainIQ access for Silver/Gold users

### DIFF
--- a/src/components/RainIQ.jsx
+++ b/src/components/RainIQ.jsx
@@ -377,6 +377,7 @@ const mockResponses = {
 };
 
 const last4ReportQueryValues = ['maxHourlyRainfall', 'maxRolling24hRainfall', 'designStormComparison', 'stormEvents'];
+const goLive2027QueryGroups = ['Baseline Metrics', 'Compliance & Threshold Queries'];
 
 const groupedQueries = queries.reduce((acc, query) => {
   if (!acc[query.group]) {
@@ -469,20 +470,27 @@ export default function RainIQ() {
 
   const userTier = user?.clients?.[0]?.tier?.toLowerCase();
   const isBronzeTier = userTier === 'bronze';
+  const isSilverOrGoldTier = userTier === 'silver' || userTier === 'gold';
+  const goLive2027Active = isActive('GO_LIVE_2027');
+  const hasGoLive2027LimitedAccess = goLive2027Active && isSilverOrGoldTier;
 
   const canAccessRainIQ = useMemo(() => {
-    return userTier === 'platinum' || user.is_superuser || isActive('rainIQ');
-  }, [user, userTier, isActive]);
+    return userTier === 'platinum' || user.is_superuser || isActive('rainIQ') || hasGoLive2027LimitedAccess;
+  }, [user, userTier, isActive, hasGoLive2027LimitedAccess]);
 
   const canViewRainIQByEmail = RAINIQ_ALLOWED_EMAILS.includes((user.email || '').toLowerCase());
   const last4ReportsActive = isActive('last4Reports');
   const isRainIQBronzeUpgradeBlocked = isBronzeTier && isActive('blockUpgradeRainIQBronze');
-  const canViewAdvancedEventAnalytics = !isBronzeTier && (last4ReportsActive || canViewRainIQByEmail);
+  const canViewAdvancedEventAnalytics = !hasGoLive2027LimitedAccess && !isBronzeTier && (last4ReportsActive || canViewRainIQByEmail);
 
   const reportOptions = useMemo(() => {
     const showAllOptions = canViewAdvancedEventAnalytics;
 
     return Object.entries(groupedQueries).reduce((acc, [group, groupQueries]) => {
+      if (hasGoLive2027LimitedAccess && !goLive2027QueryGroups.includes(group)) {
+        return acc;
+      }
+
       const filtered = groupQueries.filter((query) => {
         const isAdvancedEventAnalyticsQuery = last4ReportQueryValues.includes(query.value);
 
@@ -498,7 +506,7 @@ export default function RainIQ() {
       }
       return acc;
     }, {});
-  }, [canViewAdvancedEventAnalytics, isBronzeTier]);
+  }, [canViewAdvancedEventAnalytics, hasGoLive2027LimitedAccess, isBronzeTier]);
 
   useEffect(() => {
     const selectedQueryIsAdvancedEventAnalytics = last4ReportQueryValues.includes(selectedQuery);


### PR DESCRIPTION
### Motivation
- Allow a staged rollout via a new feature flag so Silver and Gold users can access RainIQ when `GO_LIVE_2027` is active. 
- Ensure those Silver/Gold users are limited to only the "Baseline Metrics" and "Compliance & Threshold Queries" groups and cannot see Advanced Event Analytics.

### Description
- Added `goLive2027QueryGroups` and computed `isSilverOrGoldTier`, `goLive2027Active`, and `hasGoLive2027LimitedAccess` in `src/components/RainIQ.jsx`.
- Updated `canAccessRainIQ` to grant entry when `hasGoLive2027LimitedAccess` is true so Silver/Gold users can open RainIQ under the flag.
- Prevented advanced analytics by changing `canViewAdvancedEventAnalytics` to exclude `hasGoLive2027LimitedAccess` and by filtering `reportOptions` to only include `goLive2027QueryGroups` for flagged Silver/Gold users.

### Testing
- Ran `npm run lint` which failed due to existing repository-wide lint issues unrelated to this change.
- Ran `npm run build` which completed successfully but emitted existing JSX character warnings and a chunk-size warning; build artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38a6accd78832c8420eeb17ed54c22)