### PR TITLE
Add 'Date Location Added' field to location form

### DIFF
--- a/src/components/LocationForm.jsx
+++ b/src/components/LocationForm.jsx
@@ -20,12 +20,14 @@ const LocationForm = ({ locationToEdit = null, onSubmitSuccess }) => {
   const [showMapPicker, setShowMapPicker] = useState(false);
   const [pickedLocation, setPickedLocation] = useState(null);
   const [responseData, setResponseData] = useState(null); // Store response data
+  const [localDataDateRange, setLocalDataDateRange] = useState(null);
   const [isWorking, setIsWorking] = useState(false)
   const isEditMode = locationToEdit !== null;
   const [msg,setMsg] = useState("")
   const {isActive} = useFeatureFlags();
   const isClick2PointEnabled = isActive('click2point');
   const isClick2MapPart2Enabled = isActive('click2mapPart2');
+  const clientId = user?.clients?.[0]?.id;
 
   const navigate = useNavigate();
 
@@ -42,6 +44,27 @@ const LocationForm = ({ locationToEdit = null, onSubmitSuccess }) => {
 
     }
   }, [locationToEdit, isEditMode]);
+
+  useEffect(() => {
+    const fetchLocalDataDateRange = async () => {
+      if (!isEditMode || !locationToEdit?.id || !clientId) {
+        setLocalDataDateRange(null);
+        return;
+      }
+
+      try {
+        const response = await api.get(
+          `/api/locations/${locationToEdit.id}/local_data_date_range?client_id=${clientId}`
+        );
+        setLocalDataDateRange(response.data);
+      } catch (error) {
+        console.error('Error fetching local data date range:', error.message);
+        setLocalDataDateRange(null);
+      }
+    };
+
+    fetchLocalDataDateRange();
+  }, [locationToEdit?.id, isEditMode, clientId]);
 
   useEffect(() => {
     if (!isClick2PointEnabled) return;
@@ -190,6 +213,12 @@ const LocationForm = ({ locationToEdit = null, onSubmitSuccess }) => {
       setMsg(<span className="text-[red]">{error.message}</span>)
       setIsWorking(false)
     }
+  };
+
+  const formatLocalDate = (date) => {
+    if (!date) return '';
+
+    return new Date(`${date}T00:00:00`).toLocaleDateString('EN-US');
   };
 
   const mapPickerCenter = isClick2MapPart2Enabled && pickedLocation ? pickedLocation : { lat: 39.5, lng: -98.35 };
@@ -387,6 +416,11 @@ const LocationForm = ({ locationToEdit = null, onSubmitSuccess }) => {
         {locationToEdit?.id && <div className='flex flex-col gap-2 my-4'>
           <label className='text-sm'>Date data began</label>
           <input className="text p-2 border rounded  border-slate-200" readOnly disabled value={new Date(locationToEdit?.created_at).toLocaleDateString("EN-US")}/>
+        </div>}
+
+        {locationToEdit?.id && <div className='flex flex-col gap-2 my-4'>
+          <label className='text-sm'>Date Location Added</label>
+          <input className="text p-2 border rounded  border-slate-200" readOnly disabled value={formatLocalDate(localDataDateRange?.min_local_date)}/>
         </div>}
 
         {/* Action Buttons */}


### PR DESCRIPTION
### Motivation
- Display the location's `min_local_date` (the local data start date) on the location edit form so users can see when local data first became available. 
- Make the new field read-only and styled consistently with the existing `Date data began` field.

### Description
- Added `localDataDateRange` state and a `clientId` helper in `src/components/LocationForm.jsx` to hold the API response and client context.  
- Added a `useEffect` that fetches `/api/locations/{location_id}/local_data_date_range?client_id={client_id}` when editing a location and stores the response in `localDataDateRange`.  
- Added `formatLocalDate` helper to format `min_local_date` and rendered a read-only `Date Location Added` input populated from `localDataDateRange?.min_local_date`, styled like the existing `Date data began` input.  
- Changes are confined to `src/components/LocationForm.jsx`.

### Testing
- Ran `npm run build`, which completed successfully though Vite emitted pre-existing JSX transform warnings and a chunk-size warning.  
- Ran `npm run lint`, which failed due to existing repository-wide lint errors unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b34c22a44832ca2f18847af70312d)