### PR TITLE
Add gap_hours to RainIQ storm-events POST body

### DIFF
--- a/src/components/RainIQ.jsx
+++ b/src/components/RainIQ.jsx
@@ -1514,6 +1514,7 @@ export default function RainIQ() {
         location_ids: locationIds,
         include_zero_days: includeZeroDays,
         ...(showThresholdInput && parsedThreshold !== null ? { threshold_inches: parsedThreshold } : {}),
+        ...(selectedQuery === 'stormEvents' ? { gap_hours: Number(eventGapHours) } : {}),
         ...(['maxHourlyRainfall', 'maxRolling24hRainfall', 'designStormComparison', 'stormEvents'].includes(selectedQuery) ? { data_source: 'hourly' } : {}),
       });
 


### PR DESCRIPTION
### Motivation
- Include the RainIQ "Event gap boundary (hours)" UI value in the `storm-events` API request so the backend receives the `gap_hours` parameter and event grouping matches the UI.

### Description
- Add `...(selectedQuery === 'stormEvents' ? { gap_hours: Number(eventGapHours) } : {})` to the POST payload in `src/components/RainIQ.jsx` for `stormEvents` queries.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm run lint` which failed due to existing repository-wide lint errors unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3beeab0de8832c9cf8d8599038cca3)