### PR TITLE
Fix RainIQ design storm duration handling

### DIFF
--- a/src/components/RainIQ.jsx
+++ b/src/components/RainIQ.jsx
@@ -376,6 +376,31 @@ const mockResponses = {
   },
 };
 
+
+const getDesignStormComparisonData = (locationData, selectedDuration) => {
+  const atlasComparison = locationData?.atlas14_comparison || {};
+  const durationKey = selectedDuration || locationData?.duration || '24h';
+  const durationComparison = atlasComparison?.[durationKey] || atlasComparison?.durations?.[durationKey] || atlasComparison;
+
+  return {
+    duration: durationKey,
+    observed: Number(
+      locationData?.observed_max_by_duration?.[durationKey]
+      ?? durationComparison?.observed_inches
+      ?? locationData?.observed_max_inches
+      ?? atlasComparison?.observed_inches
+      ?? 0,
+    ),
+    observedDatetime:
+      locationData?.observed_max_datetime_by_duration?.[durationKey]
+      ?? durationComparison?.observed_max_datetime
+      ?? locationData?.observed_max_datetime,
+    comparisons: durationComparison?.comparisons || [],
+    highestExceeded: durationComparison?.highest_exceeded_return_period_years,
+    exceedanceSummary: durationComparison?.exceedance_summary || locationData?.exceedance_summary,
+  };
+};
+
 const last4ReportQueryValues = ['maxHourlyRainfall', 'maxRolling24hRainfall', 'designStormComparison', 'stormEvents'];
 const goLive2027QueryGroups = ['Baseline Metrics', 'Compliance & Threshold Queries'];
 
@@ -977,26 +1002,31 @@ export default function RainIQ() {
 
 
       if (selectedQuery === 'designStormComparison' && reportLocationData) {
-        const observed = Number(reportLocationData.observed_max_inches || reportLocationData.atlas14_comparison?.observed_inches || 0);
-        const observedTs = formatDateTimeFromSql(reportLocationData.observed_max_datetime);
-        const duration = reportLocationData.duration || designStormDuration;
-        const comparisons = reportLocationData.atlas14_comparison?.comparisons || [];
-        const highestExceeded = reportLocationData.atlas14_comparison?.highest_exceeded_return_period_years;
+        const {
+          duration,
+          observed,
+          observedDatetime,
+          comparisons,
+          highestExceeded,
+          exceedanceSummary,
+        } = getDesignStormComparisonData(reportLocationData, designStormDuration);
+        const observedTs = formatDateTimeFromSql(observedDatetime);
         const selectedReturn = Number(designStormReturnPeriod);
         const selectedExceeded = comparisons.find((c) => Number(c.return_period_years) === selectedReturn)?.exceeded;
+        const durationLabel = duration === '1h' ? '1-hour' : '24-hour';
 
         return {
           id: locationId,
           locationName: reportLocationData.location_name || locationName,
           headline: selectedExceeded
-            ? `The observed rainfall at ${reportLocationData.location_name || locationName} exceeded the ${selectedReturn}-year ${duration} design storm on ${observedTs.date} at ${observedTs.time} with ${formatRainValue(observed)} inches.`
-            : `The observed rainfall at ${reportLocationData.location_name || locationName} did not exceed the ${selectedReturn}-year ${duration} design storm.`,
+            ? `The observed rainfall at ${reportLocationData.location_name || locationName} exceeded the ${selectedReturn}-year ${durationLabel} design storm on ${observedTs.date} at ${observedTs.time} with ${formatRainValue(observed)} inches.`
+            : `The observed rainfall at ${reportLocationData.location_name || locationName} did not exceed the ${selectedReturn}-year ${durationLabel} design storm.`,
           metrics: [
+            { label: 'Duration', value: durationLabel },
             { label: 'Observed maximum', value: `${formatRainValue(observed)} in` },
-            { label: 'Observed date/time', value: `${observedTs.date} ${observedTs.time}` },
-            { label: 'Exceedance summary', value: reportLocationData.exceedance_summary || (highestExceeded ? `Exceeded ${highestExceeded}-year level` : 'This event remained below the 1-year level.') },
+            { label: 'Exceedance summary', value: exceedanceSummary || (highestExceeded ? `Exceeded ${highestExceeded}-year level` : 'This event remained below the 1-year level.') },
           ],
-          columns: ['Return period (years)', 'Threshold (in)', 'Exceeded'],
+          columns: ['Return period (years)', `${durationLabel} threshold (in)`, 'Exceeded'],
           rows: comparisons.map((c) => [String(c.return_period_years), formatRainValue(c.threshold_inches), c.exceeded ? 'Yes' : 'No']),
           chart: comparisons.map((c) => ({ label: `${c.return_period_years}-yr`, value: Number(c.threshold_inches || 0) })),
         };
@@ -1514,7 +1544,12 @@ export default function RainIQ() {
         location_ids: locationIds,
         include_zero_days: includeZeroDays,
         ...(showThresholdInput && parsedThreshold !== null ? { threshold_inches: parsedThreshold } : {}),
-        ...(['maxHourlyRainfall', 'maxRolling24hRainfall', 'designStormComparison', 'stormEvents'].includes(selectedQuery) ? { data_source: 'hourly' } : {}),
+        ...(['maxHourlyRainfall', 'maxRolling24hRainfall', 'designStormComparison', 'stormEvents'].includes(selectedQuery) ? { data_source: hourlyDataSource } : {}),
+        ...(selectedQuery === 'designStormComparison' ? {
+          duration: designStormDuration,
+          design_storm_duration: designStormDuration,
+          return_period_years: Number(designStormReturnPeriod),
+        } : {}),
       });
 
       activeQueryConfig.setResponse(data);


### PR DESCRIPTION
### Motivation
- Ensure the RainIQ "Compare rainfall to design storm (NOAA Atlas 14)" feature respects the user-selected duration (1-hour vs 24-hour) when building comparison cards and threshold charts. 
- Make the API request include the chosen duration and return period so the backend can return duration-specific comparisons. 

### Description
- Added `getDesignStormComparisonData` to normalize atlas14 comparison data by the selected duration and to read duration-specific observed values, timestamps, comparisons, and exceedance summaries. (modified `src/components/RainIQ.jsx`).
- Updated the design-storm result rendering to use the normalized duration data and to label tables/metrics with the selected `1h`/`24h` duration. (modified `src/components/RainIQ.jsx`).
- Send the selected `designStormDuration` and `designStormReturnPeriod` with the design storm comparison API request and use the selected `hourlyDataSource` for advanced analytics requests instead of hardcoding `hourly`. (modified `src/components/RainIQ.jsx`).

### Testing
- `npm run build` completed successfully; Vite produced existing JSX parsing warnings and a chunk-size warning but the build exited successfully. 
- `npm run lint` failed due to pre-existing repository-wide lint errors unrelated to this change. 
- `npx eslint src/components/RainIQ.jsx` ran and only reported existing hook dependency warnings; there were no new lint errors for the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3befa2d7ac832cabcf0762c91fd231)